### PR TITLE
Add WalletUnlockerReady callback when wallet unlocker is ready

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -1259,6 +1259,7 @@ func waitForWalletPassword(cfg *Config, restEndpoints []net.Addr,
 		go func() {
 			rpcsLog.Infof("Password gRPC proxy started at %s",
 				lis.Addr())
+			js.Global().Call("WalletUnlockerReady")
 			wg.Done()
 			_ = srv.Serve(lis)
 		}()


### PR DESCRIPTION
This PR adds a callback to a `global.WalletUnlockerReady` function when the wallet unlocker service is ready to receive API calls.