### PR TITLE
Fix for preload graph issue

### DIFF
--- a/channeldb/peers.go
+++ b/channeldb/peers.go
@@ -91,6 +91,10 @@ func (d *DB) ReadFlapCount(pubkey route.Vertex) (*FlapCount, error) {
 	if err := kvdb.View(d, func(tx kvdb.RTx) error {
 		peers := tx.ReadBucket(peersBucket)
 
+		if peers == nil {
+			return ErrNoPeerBucket
+		}
+
 		peerBucket := peers.NestedReadBucket(pubkey[:])
 		if peerBucket == nil {
 			return ErrNoPeerBucket


### PR DESCRIPTION
In the case of read peer bucket return nil, any operation on it will crash with nil deference pointer

#### Pull Request Checklist

- [ ] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [ ] All changes are Go version 1.12 compliant
- [ ] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [ ] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [ ] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [ ] Any new logging statements use an appropriate subsystem and
  logging level
- [ ] Code has been formatted with `go fmt`
- [ ] Protobuf files (`lnrpc/**/*.proto`) have been formatted with
  `make rpc-format` and compiled with `make rpc`
- [ ] New configuration flags have been added to `sample-lnd.conf`
- [ ] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [ ] Running `make check` does not fail any tests
- [ ] Running `go vet` does not report any issues
- [ ] Running `make lint` does not report any **new** issues that did not
  already exist
- [ ] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [ ] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
